### PR TITLE
Fix `this` type in TS 4.9

### DIFF
--- a/index.js
+++ b/index.js
@@ -11,6 +11,7 @@ import {directiveFromMarkdown, directiveToMarkdown} from 'mdast-util-directive'
  * Plugin to support the generic directives proposal (`:cite[smith04]`,
  * `::youtube[Video of a cat in a box]{v=01ab2cd3efg}`, and such).
  *
+ * @this {import('unified').Processor}
  * @type {import('unified').Plugin<void[], Root>}
  */
 export default function remarkDirective() {


### PR DESCRIPTION
<!--
  Please check the needed checkboxes ([ ] -> [x]). Leave the
  comments as they are, they won’t show on GitHub.
  We are excited about pull requests, but please try to limit the scope, provide
  a general description of the changes, and remember, it’s up to you to convince
  us to land it.
-->

### Initial checklist

*   [x] I read the support docs <!-- https://github.com/remarkjs/.github/blob/main/support.md -->
*   [x] I read the contributing guide <!-- https://github.com/remarkjs/.github/blob/main/contributing.md -->
*   [x] I agree to follow the code of conduct <!-- https://github.com/remarkjs/.github/blob/main/code-of-conduct.md -->
*   [x] I searched issues and couldn’t find anything (or linked relevant results below) <!-- https://github.com/search?q=user%3Aremarkjs&type=Issues -->
*   [x] If applicable, I’ve added docs and tests

### Description of changes

fixes typing

<!--do not edit: pr-->
